### PR TITLE
Fix dependency case for Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Color = require('Color');
+var Color = require('color');
 var colors = require('./colors.json');
 var optimist = require('optimist');
 


### PR DESCRIPTION
'Color' should be 'color' - otherwise, this library breaks on Linux systems (but works on OS X).
